### PR TITLE
feat: play audio on scroll for first-time visitors

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -34,28 +34,44 @@ export default function LandingPage() {
   const { theme, setTheme, resolvedTheme } = useTheme();
   const [navbarHeight, setNavbarHeight] = useState(0);
   const navbarRef = useRef<HTMLElement>(null);
-  const [showAudio, setShowAudio] = useState(false);
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const [isFirstVisit, setIsFirstVisit] = useState(false);
 
   useEffect(() => {
     if (navbarRef.current) {
       setNavbarHeight(navbarRef.current.offsetHeight);
     }
+
     const hasVisited = localStorage.getItem('hasVisitedBefore');
     if (!hasVisited) {
-      setShowAudio(true);
+      setIsFirstVisit(true);
       localStorage.setItem('hasVisitedBefore', 'true');
     }
   }, []);
 
+  useEffect(() => {
+    const playAudio = () => {
+      audioRef.current?.play().catch(error => {
+        console.error("Audio play failed:", error);
+      });
+    };
+
+    if (isFirstVisit) {
+      window.addEventListener('scroll', playAudio, { once: true });
+    }
+
+    return () => {
+      window.removeEventListener('scroll', playAudio);
+    };
+  }, [isFirstVisit]);
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-background via-surface-secondary to-background">
-      {showAudio && (
-        <div className="fixed bottom-4 right-4 z-50">
-        <audio autoPlay>
+      {isFirstVisit && (
+        <audio ref={audioRef} preload="auto">
           <source src="/paranoid-instrumental.mp3" type="audio/mpeg" />
           Your browser does not support the audio element.
         </audio>
-        </div>
       )}
       {/* Header */}
       <header className="border-b bg-surface/95 backdrop-blur-md sticky top-0 z-50 shadow-sm">


### PR DESCRIPTION
Implements a feature to play a temporary audio track when a user visits the landing page for the first time.

To comply with browser autoplay policies, the audio playback is initiated by the user's first scroll action on the page.

- Uses localStorage to detect a first-time visit.
- Adds a scroll event listener that triggers audio playback once.
- The audio element is hidden from the user (no controls).